### PR TITLE
Note that PHP 7.4 and earlier requires windows-2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ for building and testing PHP extensions on Windows.
 - `deps`: dependency libraries to install; for now, only
   [core dependencies](https://windows.php.net/downloads/php-sdk/deps/) are available
 
-Note that for PHP versions 7.2 and below, `runs-on: windows-2022` will not work
+Note that for PHP versions 7.4 and below, `runs-on: windows-2022` will not work
 as the correct toolset is not available. For these versions, you should use
 `runs-on: windows-2019`. For example:
 
@@ -45,8 +45,8 @@ strategy:
     exclude:
       - { os: windows-2019, php: "8.1" }
       - { os: windows-2019, php: "8.0" }
-      - { os: windows-2019, php: "7.4" }
-      - { os: windows-2019, php: "7.3" }
+      - { os: windows-2022, php: "7.4" }
+      - { os: windows-2022, php: "7.3" }
       - { os: windows-2022, php: "7.2" }
       - { os: windows-2022, php: "7.1" }
 ```

--- a/README.md
+++ b/README.md
@@ -65,43 +65,18 @@ to allow building PHP 7.2, 7.3, and 7.4 on a `windows-2022` image:
 ```yml
 run:
   steps:
-    - name: Delete components
+    - name: Install VC15 component
+      if: ${{ matrix.php == '7.4' || matrix.php == '7.3' || matrix.php == '7.2' }}
       shell: pwsh
       run: |
               Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-              $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-              $componentsToRemove= @(
-                "Microsoft.VisualStudio.Component.VC.v141.x86.x64"
-              )
-              [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --remove " +  $_}
-              $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-              # should be run twice
-              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-
-    - name: Install components
-      shell: pwsh
-      run: |
-              Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-              $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-              $componentsToRemove= @(
-                "Microsoft.VisualStudio.Component.VC.v141.x86.x64"
-              )
-              [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --add " +  $_}
-              $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-              # should be run twice
-              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+              $installPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+              $component = "Microsoft.VisualStudio.Component.VC.v141.x86.x64"
+              $args = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$installPath`"", '--add', $component, '--quiet', '--norestart', '--nocache')
+              $process = Start-Process -FilePath cmd.exe -ArgumentList $args -Wait -PassThru -WindowStyle Hidden
 ```
 
-These steps should be executed _before_ invoking the `setup-php-sdk` action.
-
-An [`if` conditional](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif)
-can also be used to limit these steps to specific PHP versions. For example:
-
-```yml
-if: ${{ matrix.php == '7.4' || matrix.php == '7.3' || matrix.php == '7.2' }}
-```
+This step should be executed _before_ invoking the `setup-php-sdk` action.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,55 @@ strategy:
 Currently, `windows-2019` may be used for all PHP versions, although this may
 change in future releases.
 
+### Manually Installing Toolsets
+
+It is possible to manually install older toolsets on `windows-2022` using an
+approach suggested in [actions/runner-images#9701](https://github.com/actions/runner-images/issues/9701).
+The following example installs VC15 by its
+[Component ID](https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022)
+to allow building PHP 7.2, 7.3, and 7.4 on a `windows-2022` image:
+
+```yml
+run:
+  steps:
+    - name: Delete components
+      shell: pwsh
+      run: |
+              Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+              $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+              $componentsToRemove= @(
+                "Microsoft.VisualStudio.Component.VC.v141.x86.x64"
+              )
+              [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --remove " +  $_}
+              $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+              # should be run twice
+              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+
+    - name: Install components
+      shell: pwsh
+      run: |
+              Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+              $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+              $componentsToRemove= @(
+                "Microsoft.VisualStudio.Component.VC.v141.x86.x64"
+              )
+              [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --add " +  $_}
+              $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+              # should be run twice
+              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+```
+
+These steps should be executed _before_ invoking the `setup-php-sdk` action.
+
+An [`if` conditional](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif)
+can also be used to limit these steps to specific PHP versions. For example:
+
+```yml
+if: ${{ matrix.php == '7.4' || matrix.php == '7.3' || matrix.php == '7.2' }}
+```
+
 ## Outputs
 
 - `toolset`: the required toolset version;


### PR DESCRIPTION
GitHub recently removed vc15 from the windows-2022 image (see: actions/runner-images#9701).

The linked thread does discuss "Mitigation ways" to manually install missing toolsets, but I've yet to verify that. We recently encountered this in https://github.com/mongodb/mongo-php-driver/pull/1555#issuecomment-2124768268 and I'm in the process of fixing the `ext-mongodb` builds (tracked in [PHPC-2388](https://jira.mongodb.org/browse/PHPC-2388)). I anticipate manual installation will be necessary in our case, since other parts of our release process will rely on windows-2022; however, that seems beyond the scope of this action's README.