### PR TITLE
Fix installation of older PHP versions

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -83,14 +83,20 @@ Write-Output "Install PHP $phpversion ..."
 $temp = New-TemporaryFile | Rename-Item -NewName {$_.Name + ".zip"} -PassThru
 $fname = "php-$phpversion-$tspart-$vs-$arch.zip"
 $url = "$baseurl/$fname"
-Invoke-WebRequest $url -OutFile $temp
+Try {
+    Invoke-WebRequest $url -OutFile $temp
+} Catch {
+    $archive = "archives/"
+    $url = "$baseurl/$archive$fname"
+    Invoke-WebRequest $url -OutFile $temp
+}
 Expand-Archive $temp "php-bin"
 
 Write-Output "Install development pack ..."
 
 $temp = New-TemporaryFile | Rename-Item -NewName {$_.Name + ".zip"} -PassThru
 $fname = "php-devel-pack-$phpversion-$tspart-$vs-$arch.zip"
-$url = "$baseurl/$fname"
+$url = "$baseurl/$archive$fname"
 Invoke-WebRequest $url -OutFile $temp
 Expand-Archive $temp "."
 Rename-Item "php-$phpversion-devel-$vs-$arch" "php-dev"


### PR DESCRIPTION
Archives for old PHP versions are now in an `archives` subfolder, which breaks installs for PHP < 8.1. This PR changes the download logic to first try downloading from `/releases/<file>`, and trying `/releases/archives/<file>` as a fallback if the first request fails. This is also done for the devel-pack file.