### PR TITLE
Use tagged version of php-sdk-binary-tools

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -47,10 +47,10 @@ if (-not $toolset) {
 Write-Output "Install PHP SDK ..."
 
 $temp = New-TemporaryFile | Rename-Item -NewName {$_.Name + ".zip"} -PassThru
-$url = "https://github.com/php/php-sdk-binary-tools/archive/refs/heads/master.zip"
+$url = "https://github.com/php/php-sdk-binary-tools/archive/refs/tags/php-sdk-2.3.0.zip"
 Invoke-WebRequest $url -OutFile $temp
 Expand-Archive $temp -DestinationPath "."
-Rename-Item "php-sdk-binary-tools-master" "php-sdk"
+Rename-Item "php-sdk-binary-tools-php-sdk-2.3.0" "php-sdk"
 
 $baseurl = "https://downloads.php.net/~windows/releases/archives"
 $releases = @{


### PR DESCRIPTION
See <https://github.com/php/php-sdk-binary-tools?tab=readme-ov-file#internal-notes>.

According to that documentation, for PHP 7.0 and 7.1, PHP SDK 2.1 would be required; however, we already used newer versions, and so far nobody had complained, apparently.  So maybe the php-sdk-binary-tools README is not quite correct, or we would need to adapt the tag for those PHP versions.  On the other hand, it is somewhat unlikely that these old versions are still in use, so we don't care too much about that.