### PR TITLE
Support building for PHP 8.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ for building and testing PHP extensions on Windows.
 ## Inputs
 
 - `version`: the PHP version to build for
-  (`7.0`, `7.1`, `7.2`, `7.3`, `7.4`, `8.0`, `8.1`, `8.2` or `8.3`)
+  (`7.0`, `7.1`, `7.2`, `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, or `8.4`)
 - `arch`: the architecture to build for (`x64` or `x86`)
 - `ts`: thread-safety (`nts` or `ts`)
 - `deps`: dependency libraries to install; for now, only

--- a/run.ps1
+++ b/run.ps1
@@ -17,6 +17,7 @@ $versions = @{
     "8.1" = "vs16"
     "8.2" = "vs16"
     "8.3" = "vs16"
+    "8.4" = "vs17"
 }
 $vs = $versions.$version
 if (-not $vs) {


### PR DESCRIPTION
Since alpha pre-releases are already available, it seems to be prudent to offer clients the ability to test their extensions for PHP 8.4 in CI.

---

With this patch, I've been able to [build PECL/dbase for PHP 8.4](https://github.com/php/pecl-database-dbase/actions/runs/10064596265/job/27828230994). Since dbase requires no additional dependencies, this part of the code has not been checked yet, but I don't expect any issues.

Any objections to merge this? And I would like to tag `v0.9` immediately after the merge, if nobody objects.

/cc @shivammathur 