### PR TITLE
Download a release asset instead of a tag archive

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -48,7 +48,7 @@ if (-not $toolset) {
 Write-Output "Install PHP SDK ..."
 
 $temp = New-TemporaryFile | Rename-Item -NewName {$_.Name + ".zip"} -PassThru
-$url = "https://github.com/php/php-sdk-binary-tools/archive/refs/tags/php-sdk-2.3.0.zip"
+$url = "https://github.com/php/php-sdk-binary-tools/releases/download/php-sdk-2.3.0/php-sdk-binary-tools-php-sdk-2.3.0.zip"
 Invoke-WebRequest $url -OutFile $temp
 Expand-Archive $temp -DestinationPath "."
 Rename-Item "php-sdk-binary-tools-php-sdk-2.3.0" "php-sdk"


### PR DESCRIPTION
This may solve the issues reported in #12, and even if there would still be issues, it seems reasonable to download a release asset, instead having GH to create a tag archive for [stability reasons](https://docs.github.com/en/repositories/working-with-files/using-files/downloading-source-code-archives#stability-of-source-code-archives).