### PR TITLE
Close #8: Implement caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ for building and testing PHP extensions on Windows.
 - `ts`: thread-safety (`nts` or `ts`)
 - `deps`: dependency libraries to install; for now, only
   [core dependencies](https://windows.php.net/downloads/php-sdk/deps/) are available
+- `cache`: whether to cache the PHP SDK, PHP and development pack
 
 Note that for PHP versions 7.4 and below, `runs-on: windows-2022` will not work
 as the correct toolset is not available. For these versions, you should use

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,11 @@ inputs:
     description: "List of dependency libraries"
     required: false
     default: '@()'
+  cache:
+    description: "Whether the PHP-SDK should be cached"
+    type: boolean
+    required: false
+    default: false
 outputs:
   toolset:
     description: "The required toolset version"
@@ -27,6 +32,24 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Determine current PHP revision
+      id: revision
+      run: ${{github.action_path}}/determine-revision -version ${{inputs.version}}
+      shell: powershell
+    - name: Cache PHP SDK
+      if: ${{inputs.cache == 'true'}}
+      uses: actions/cache@v4
+      with:
+        path: php-sdk
+        key: php-sdk-2.3.0
+    - name: Cache PHP
+      if: ${{inputs.cache == 'true'}}
+      uses: actions/cache@v4
+      with:
+        path: |
+            php-bin
+            php-dev
+        key: php-${{steps.revision.outputs.version}}-${{inputs.arch}}-${{inputs.ts}}
     - id: setup
-      run: ${{github.action_path}}/run -version ${{inputs.version}} -arch ${{inputs.arch}} -ts ${{inputs.ts}} -deps ${{inputs.deps}}
+      run: ${{github.action_path}}/run -version ${{inputs.version}} -revision ${{steps.revision.outputs.version}} -baseurl ${{steps.revision.outputs.baseurl}} -arch ${{inputs.arch}} -ts ${{inputs.ts}} -deps ${{inputs.deps}}
       shell: powershell

--- a/determine-revision.ps1
+++ b/determine-revision.ps1
@@ -1,0 +1,34 @@
+param (
+    [Parameter(Mandatory)] [String] $version
+)
+
+$ErrorActionPreference = "Stop"
+
+$baseurl = "https://downloads.php.net/~windows/releases/archives"
+$releases = @{
+    "7.0" = "7.0.33"
+    "7.1" = "7.1.33"
+    "7.2" = "7.2.34"
+    "7.3" = "7.3.33"
+    "7.4" = "7.4.33"
+    "8.0" = "8.0.30"
+}
+$phpversion = $releases.$version
+if (-not $phpversion) {
+    $baseurl = "https://downloads.php.net/~windows/releases"
+    $url = "$baseurl/releases.json"
+    $releases = Invoke-WebRequest $url | ConvertFrom-Json
+    $phpversion = $releases.$version.version
+    if (-not $phpversion) {
+        $baseurl = "https://downloads.php.net/~windows/qa"
+        $url = "$baseurl/releases.json"
+        $releases = Invoke-WebRequest $url | ConvertFrom-Json
+        $phpversion = $releases.$version.version
+        if (-not $phpversion) {
+            throw "unknown version"
+        }
+    }
+}
+
+Write-Output "version=$phpversion" >> $Env:GITHUB_OUTPUT
+Write-Output "baseurl=$baseurl" >> $Env:GITHUB_OUTPUT


### PR DESCRIPTION
For now we cache only the PHP SDK, the PHP binaries and the development packs.  This already greatly improves the setup performance (it might easily safe a minute or two, in case of cache hits).  To be able to use the current PHP revision as part of the cache key, we factor out determine-revision.ps1.  We create a separate cache for the PHP-SDK since this likely rarely changes, and since the cached variant is apparently much faster than fetching a GH release of the PHP-SDK.

Since clients may not want to use the cache, possibly because they have already a lot of other files in their caches, we explicitly require clients to opt-in via the `cache` input parameter.

---

I encourage all users of setup-sdk-action to try this out. See https://github.com/php/pecl-database-dbase/actions/runs/11094514089 for a demonstation; php-sdk-2.3.0, php-7.4.33-x64-ts and php-8.4.0RC1-x64-ts had already been cached prior to this run; still a nice performance improvement for the other PHP versions. Now compare that with your setup times (likely two to four minutes per job).
